### PR TITLE
CI: Fix branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
         shell: bash
         run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
 
+      - name: Debug
+        run: echo ${{ env.BRANCH_NAME }}
+
       - name: deploy to gh pages
         run: |
           echo "Deploying to directory: ${{env.BRANCH_NAME}}"


### PR DESCRIPTION
Branch name resolution only work for feature branches in PR, not on `main` push.