### PR TITLE
GSREN3D-156: make the photo gallery retractable

### DIFF
--- a/src/components/home/PhotoGallery.vue
+++ b/src/components/home/PhotoGallery.vue
@@ -27,12 +27,10 @@ function toggleGallery() {
 </script>
 
 <template>
-  <div class="bg-transparent">
-    <UiPhotoGalery
-      :photos="photoUrls"
-      :galleryShown="photosStore.isGalleryShown"
-      @toggleEvent="toggleGallery"
-    >
-    </UiPhotoGalery>
-  </div>
+  <UiPhotoGalery
+    :photos="photoUrls"
+    :galleryShown="photosStore.isGalleryShown"
+    @toggleEvent="toggleGallery"
+  >
+  </UiPhotoGalery>
 </template>

--- a/src/components/ui/UiPhotoGalery.vue
+++ b/src/components/ui/UiPhotoGalery.vue
@@ -21,7 +21,7 @@ function sendEvent() {
 }
 </script>
 <template>
-  <div class="flex flex-col items-center justify-end p-0 h-64">
+  <div class="flex flex-col items-center justify-end p-0">
     <button
       @click="sendEvent"
       class="flex flex-row justify-center items-center px-2 py-4 gap-4 w-11 h-7 bg-white rounded-t-xl"

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -18,7 +18,7 @@ import UiTrambusTitle from '../components/ui/UiTrambusTitle.vue'
     <div class="flex grow relative">
       <MapComponent></MapComponent>
     </div>
-    <div class="z-10 absolute inset-x-0 bottom-0">
+    <div class="z-10 absolute inset-x-0 bottom-0 max-w-max m-auto">
       <PhotoGallery></PhotoGallery>
     </div>
   </main>


### PR DESCRIPTION
<!-- Title must be: GSREN3D-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSREN3D-156

### Description

Continuing #13 or fixing the issue where the photo gallery covering the map and the 2D/3D switch button.

### Screenshots
![Peek 2022-10-03 05-38 - retractable photo gallery](https://user-images.githubusercontent.com/1421861/193497960-66bb9fd8-b5ec-46d5-9769-b27d35758801.gif)


