### PR TITLE
GSREN3D-165: Use lazy loading for planning view.

### DIFF
--- a/src/components/map/MapComponent.vue
+++ b/src/components/map/MapComponent.vue
@@ -37,12 +37,18 @@ layerStore.$subscribe(() => {
   setLayerVisible('bus', layerStore.visibilities.bus)
   setLayerVisible('bike', layerStore.visibilities.bike)
 })
+
+function onPlanningButtonClicked() {
+  panelStore.isPlanningViewShown = true
+  panelStore.hasPlanningViewRendered = true
+}
 </script>
+
 <template>
   <UiMap v-if="appLoaded"> </UiMap>
   <div class="absolute right-2 top-2 z-10 flex [&>*]:m-1">
     <TransportButtons></TransportButtons>
-    <UiButton @click="panelStore.isPlanningViewShown = true">
+    <UiButton @click="onPlanningButtonClicked">
       <IconPlanning />
       <span class="pl-2 font-semibold"> Planning du projet </span>
     </UiButton>

--- a/src/components/map/PlanningMapComponent.vue
+++ b/src/components/map/PlanningMapComponent.vue
@@ -127,8 +127,7 @@ const planningLayer = new VectorLayer({
   style: styleFunction,
 })
 
-onMounted(async () => {
-  // Setup map here
+function setupMap() {
   map.setTarget('mapContainer')
   map.setView(
     new View({
@@ -138,6 +137,10 @@ onMounted(async () => {
   )
   map.setLayers([rennesBaseMap, planningLayer])
   mapLoaded.value = true
+}
+
+onMounted(async () => {
+  setupMap()
 })
 
 planningStore.$subscribe(() => {

--- a/src/components/ui/UiOLMap.vue
+++ b/src/components/ui/UiOLMap.vue
@@ -14,7 +14,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div ref="mapContainer" class="h-full w-full"></div>
+  <div ref="mapContainer" class="h-full w-full bg-gray-100"></div>
 </template>
 
 <style scoped>

--- a/src/stores/panels.ts
+++ b/src/stores/panels.ts
@@ -6,6 +6,8 @@ export const usePanelsStore = defineStore('panels', () => {
   const isGalleryShown: Ref<boolean> = ref(false)
   const isInformationPanelShown: Ref<boolean> = ref(true)
   const isPlanningViewShown: Ref<boolean> = ref(false)
+  // This is used to do lazy loading on the planning view
+  const isPlanningViewAlreadyShown: Ref<boolean> = ref(false)
 
   function toggleGallery() {
     isGalleryShown.value = !isGalleryShown.value
@@ -20,5 +22,6 @@ export const usePanelsStore = defineStore('panels', () => {
     isInformationPanelShown,
     toggleInformationPanel,
     isPlanningViewShown,
+    hasPlanningViewRendered: isPlanningViewAlreadyShown,
   }
 })

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -19,9 +19,12 @@ const panelStore = usePanelsStore()
     <div class="z-10 absolute inset-x-0 bottom-0 max-w-max m-auto">
       <PhotoGallery></PhotoGallery>
     </div>
+    <!--Do lazy loading for planning view.
+      Only render it once, and after that 'hide' the planning view so that we can keep its state and no need to load it again. -->
     <div
-      class="absolute h-screen w-screen z-20"
-      v-if="panelStore.isPlanningViewShown"
+      class="absolute h-screen w-screen"
+      v-if="panelStore.hasPlanningViewRendered"
+      :class="panelStore.isPlanningViewShown ? 'z-20' : '-z-10'"
     >
       <PlanningView></PlanningView>
     </div>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -20,8 +20,8 @@ const panelStore = usePanelsStore()
       <PhotoGallery></PhotoGallery>
     </div>
     <div
-      class="absolute h-screen w-screen"
-      :class="panelStore.isPlanningViewShown ? 'z-20' : '-z-10'"
+      class="absolute h-screen w-screen z-20"
+      v-if="panelStore.isPlanningViewShown"
     >
       <PlanningView></PlanningView>
     </div>


### PR DESCRIPTION
<!-- Title must be: GSREN3D-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSREN3D-165

### Description

- Only render/load the planning view when it's needed
- Do the rendering/loading only once (only 'hide" it), so no need to reload/rerender and we can still have the planning view state (e.g. keeping the map extent), better UX IMHO

### Screenshots

(only if the final render is different)
![Peek 2022-10-21 06-34 - lazy loading planning view](https://user-images.githubusercontent.com/1421861/197078561-7ccf3297-9680-4e77-b999-f56f9f7dd45b.gif)
